### PR TITLE
Disable "Edit on Github" links in Qi Docs

### DIFF
--- a/common/_static/docs.css
+++ b/common/_static/docs.css
@@ -8,3 +8,6 @@ hr.docutils {
     color: #000;
     height: 2px;
 }
+fa-github {
+ display:none;
+}

--- a/common/_static/docs.css
+++ b/common/_static/docs.css
@@ -8,6 +8,6 @@ hr.docutils {
     color: #000;
     height: 2px;
 }
-.fa-github {
+.fa fa-github {
  display:none;
 }

--- a/common/_static/docs.css
+++ b/common/_static/docs.css
@@ -9,5 +9,5 @@ hr.docutils {
     height: 2px;
 }
 .fa-github {
- display: none;
+ display: none !important;
 }

--- a/common/_static/docs.css
+++ b/common/_static/docs.css
@@ -8,6 +8,6 @@ hr.docutils {
     color: #000;
     height: 2px;
 }
-fa-github {
+.fa-github {
  display:none;
 }

--- a/common/_static/docs.css
+++ b/common/_static/docs.css
@@ -8,6 +8,6 @@ hr.docutils {
     color: #000;
     height: 2px;
 }
-.fa fa-github {
- display:none;
+.fa-github {
+ display: none;
 }


### PR DESCRIPTION
This change disables the "Edit on Github" links in the Qi Docs site.